### PR TITLE
Make some background colors and text colors configurable through new `style` configuration object

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,6 +52,8 @@
     "backgroundColor": "#212121",
     "messageColor": "#fff",
     "dateColor": "#d9d9d9",
+    "lineColor": "#fff",
+    "weatherColor": "#d9d9d9",
     "searchColor": "#fff",
     "searchBackgroundColor": "#2e2e2e",
     "squareColor": "#9e9e9e",

--- a/config.json
+++ b/config.json
@@ -47,5 +47,15 @@
     "location": "Pune India",
     "unit": "cel"
   },
-  "settingsIcon": false
+  "settingsIcon": false,
+  "style": {
+    "backgroundColor": "#212121",
+    "messageColor": "#fff",
+    "dateColor": "#d9d9d9",
+    "searchColor": "#fff",
+    "searchBackgroundColor": "#2e2e2e",
+    "squareColor": "#9e9e9e",
+    "squareBackgroundColor": "#2e2e2e"
+  },
+  "backgroundColor": "#212121"
 }

--- a/css/main.css
+++ b/css/main.css
@@ -72,7 +72,8 @@ body {
         font-size: 18px;
         color: #fff;
         box-sizing: border-box;
-        z-index: -1; }
+        z-index: -1;
+        cursor: pointer; }
         .main #search-bar .autocomplete-items-container .autocomplete-item:hover {
           background: #3b3b3b; }
       .main #search-bar .autocomplete-items-container .autocomplete-active {

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -1,4 +1,4 @@
-function autocomplete(inp, passedValues) {
+function autocomplete(inp, passedValues, style) {
     var currentFocus;
 
     /*execute a function when someone writes in the text field:*/
@@ -18,6 +18,9 @@ function autocomplete(inp, passedValues) {
         parentContainer.setAttribute("id", this.id + "-autocomplete-list");
         parentContainer.style.paddingBottom = "1rem";
 
+        if(style["searchBackgroundColor"]) {
+            parentContainer.style.backgroundColor = style["searchBackgroundColor"];
+        }
 
         /*for each item in the array...*/
         Object.keys(passedValues).forEach((el, i, arr) => {
@@ -30,6 +33,14 @@ function autocomplete(inp, passedValues) {
             // Add the url as an attribute
             item.setAttribute('url', passedValues[el]);
 
+            if(style["searchBackgroundColor"]) {
+                item.style.backgroundColor = style["searchBackgroundColor"];
+            }
+
+            if(style["searchColor"]) {
+                item.style.color = style["searchColor"];
+            }
+            
             /*make the matching letters bold:*/
             item.innerHTML = "<strong>" + arr[i].substr(0, val.length) + "</strong>";
             item.innerHTML += arr[i].substr(val.length);

--- a/js/main.js
+++ b/js/main.js
@@ -135,7 +135,7 @@ function handleMessage(userName) {
      * Else, add the username before the message.
      */
     var builtMsg = buildMsg()
-    builtMsg == "" ? 
+    builtMsg == "" ?
         builtMsg = `Hello ${userName}` : builtMsg = `Hey ${userName}, ${builtMsg}!`
     return builtMsg;
 }
@@ -146,13 +146,13 @@ function updateTime() {
      */
     currentDate = new Date()
     options = {
-                day: 'numeric',
-                month: 'short',
-                hour: 'numeric',
-                minute: 'numeric',
-                hour12: disable24Hour,
-                timeZone: timeZ
-            }
+            day: 'numeric',
+            month: 'short',
+            hour: 'numeric',
+            minute: 'numeric',
+            hour12: disable24Hour,
+            timeZone: timeZ
+    }
     finalDate = currentDate.toLocaleString(undefined, options)
     document.getElementById(dateId).textContent = finalDate
 }
@@ -173,7 +173,7 @@ function updateWeather(weatherConfig) {
     userLocation = weatherConfig["location"].replace(/\ /g, ",")
     passedUnit = weatherConfig["unit"]
     unit = validWeatherUnit.includes(passedUnit.substring(0, 3)) ?
-            passedUnit : "cel"
+        passedUnit : "cel"
 
     fetchUrl = apiUrl + `?q=${userLocation}&appid=${appId}&units=metric`
 
@@ -184,7 +184,7 @@ function updateWeather(weatherConfig) {
             weatherType = jsonData["weather"][0]["main"]
 
             temp = !unit.includes("cel") ?
-                        getFahrenheit(temp) + "&deg;F" : temp + "&deg;C"
+                getFahrenheit(temp) + "&deg;F" : temp + "&deg;C"
             weatherText = temp + ", " + indexUppercase(weatherType)
             document.getElementById(weatherId).innerHTML = weatherText
         })
@@ -216,13 +216,13 @@ function parseAndCreate(jsonData) {
     if (jsonData["settingsIcon"]) enableCog();
 
     // If the user has not passed any custom message
-    if (Object.keys(jsonData).includes("message") && 
+    if (Object.keys(jsonData).includes("message") &&
             typeof(jsonData["message"]) == "string" &&
             jsonData["message"] != "")
         builtMsg = jsonData["message"]
     else
         builtMsg = this.handleMessage(this.userName);
-    
+
     document.getElementById(messageId).textContent = builtMsg
     // Check if 24 hour is disabled
     disable24Hour = jsonData["disable24Hour"]
@@ -252,14 +252,51 @@ function parseAndCreate(jsonData) {
 
     sqrs = jsonData["squares"]
 
-    // Extract the quicklinks from the sqrs
-    extractQuickLinks(sqrs);
-
     sqrs.forEach((element, index) => {
         sqr = createSqr(element, index)
         document.getElementById(otherContentId).appendChild(sqr)
     })
-    
+
+    // Apply styling if present
+    if (jsonData["style"]) {
+        styleData = jsonData["style"]
+        if (styleData["backgroundColor"]) {
+            document.body.style.backgroundColor = styleData["backgroundColor"]
+        }
+        if (styleData["messageColor"]) {
+            document.getElementById(messageId).style.color = styleData["messageColor"]
+        }
+        if (styleData["dateColor"]) {
+            document.getElementById(dateId).style.color = styleData["dateColor"]
+        }
+        if (styleData["searchColor"]) {
+            document.getElementById(searchBarId).style.color = styleData["searchColor"]
+        }
+        if (styleData["searchBackgroundColor"]) {
+            document.getElementById(searchBarId).style.backgroundColor = styleData["searchBackgroundColor"]
+            autocompleteBackgroundColor = styleData["searchBackgroundColor"]
+        }
+        if (styleData["searchPlaceholderColor"]) {
+            document.getElementById(searchBarId).classList.add(createPlaceholderStyleClass(styleData["searchPlaceholderColor"]));
+        }
+        if (styleData["squareBackgroundColor"]) {
+            elements = document.getElementsByClassName("sqr")
+            var i;
+            for (i = 0; i < elements.length; i++) {
+                elements[i].style.backgroundColor = styleData["squareBackgroundColor"]
+            }
+        }
+        if (styleData["squareColor"]) {
+            elements = document.querySelectorAll(".sqr a")
+            var i;
+            for (i = 0; i < elements.length; i++) {
+                elements[i].style.color = styleData["squareColor"]
+            }
+        }
+    }
+
+    // Extract the quicklinks from the sqrs
+    extractQuickLinks(sqrs, jsonData["style"]);
 }
 
 function createSqr(sqrData, index) {
@@ -294,7 +331,7 @@ function createSqr(sqrData, index) {
     links.forEach(element => {
         aName = element["name"]
         aHref = element["url"]
-        
+
         a = document.createElement("a")
         attrHref = document.createAttribute("href")
         attrHref.value = aHref
@@ -403,8 +440,33 @@ function createClass(color) {
     return newClassName;
 }
 
+function createPlaceholderStyleClass(color) {
+    /**
+     * Create a new class with for placeholder styling.
+     * 
+     * This is pretty much a continuation of what has done preivously
+     * in the createClass function.
+     */
+    var style = document.createElement('style');
+    const newClassName = `bg-${Math.random().toString(36).substring(7)}`;
+    style.type = 'text/css';
+    style.innerHTML = `::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+        color: ${color} !important;
+        opacity: 1; /* Firefox */
+      }
+      
+      :-ms-input-placeholder { /* Internet Explorer 10-11 */
+        color: ${color} !important;
+      }
+      
+      ::-ms-input-placeholder { /* Microsoft Edge */color: ${color} !important;}`;
+    document.getElementsByTagName('head')[0].appendChild(style);
 
-function extractQuickLinks(passedSqrs) {
+    return newClassName;
+}
+
+
+function extractQuickLinks(passedSqrs, style) {
     /**
      * Extract the quicklinks passed in the config
      * 
@@ -417,7 +479,7 @@ function extractQuickLinks(passedSqrs) {
     });
 
     // Start the autocomplete
-    autocomplete(document.getElementById("search-bar-input"), this.validQuickLinks);
+    autocomplete(document.getElementById("search-bar-input"), this.validQuickLinks, style);
 }
 
 // Listen to key click

--- a/js/main.js
+++ b/js/main.js
@@ -269,6 +269,12 @@ function parseAndCreate(jsonData) {
         if (styleData["dateColor"]) {
             document.getElementById(dateId).style.color = styleData["dateColor"]
         }
+        if (styleData["lineColor"]) {
+            document.getElementById(lineId).style.color = styleData["lineColor"]
+        }
+        if (styleData["weatherColor"]) {
+            document.getElementById(weatherId).style.color = styleData["weatherColor"]
+        }
         if (styleData["searchColor"]) {
             document.getElementById(searchBarId).style.color = styleData["searchColor"]
         }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -108,6 +108,7 @@ body {
                 color: $foreground;
                 box-sizing: border-box;
                 z-index: -1;
+                cursor: pointer;
 
                 &:hover {
                     background: lighten($background, 10);


### PR DESCRIPTION
Hey @deepjyoti30, great work so far on this project.

I set it up locally and enjoyed the simplicity but quickly found an edge case that prompted me to make this change.

I wanted to use this startpage across multiple browsers and profiles due to division in work / personal / etc but found myself needing more of a larger visual indicator as to which browser / session I was looking at. The simplest indicator I could think of was changing some colors.

I know that this could have been possible by locally changing the CSS file, but that would have meant needing multiple copies locally on my HDD, each with different CSS files. In my usecase of different configurations of it running in parallel, it felt much easier for me to rely on the browser session's local storage.

Before implementing this, I did look at previous Issues and Pull Requests to see that there had been talk about implementing some kind of theming or styling without code change.

Let me know your thoughts. More than happy to make some minor changes if this is a feature you'd like but think some things should be implemented differently.

If this does get merged, I'm more than happy to update the configuration page in the wiki to include the changes I've made.